### PR TITLE
Add typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+type JsonValue = boolean | number | string | JsonMap | JsonArray | Date;
+type JsonArray = JsonValue[];
+type AnyJson =
+    | boolean
+    | number
+    | string
+    | JsonMap
+    | Date
+    | JsonArray
+    | JsonArray[];
+
+interface JsonMap {
+    [key: string]: AnyJson;
+}
+export const dump: (value: any, context?: string[]) => string;
+export const parse: (str: string) => JsonMap;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "browser"
   ],
   "lib": "./lib",
+  "types": "index.d.ts",
   "main": "./lib/amd/toml.js",
   "author": {
     "name": "Alexander Beletsky",


### PR DESCRIPTION
Hey! This library seems to be the only browser-compatible toml.dump implementation I could find, thank you!

I'm in a typescript environment and just declared the types locally for this, but figured you may want them in the npm package. This commit will allow typescript to check this library whenever it's published.